### PR TITLE
Implemented the curl command with GET method

### DIFF
--- a/routes/terminal.js
+++ b/routes/terminal.js
@@ -1,3 +1,4 @@
+const fetch = require("node-fetch");
 const express = require('express');
 const router = express.Router();
 const { exec } = require('child_process');
@@ -22,4 +23,28 @@ router.post('/run', (req, res) => {
     });
 });
 
+// routes/terminal.js
+
+router.get('/proxy', async (req, res) => {
+    const target = req.query.url;
+    if (!target) return res.status(400).json({error:'Missing ?url='});
+    try {
+      const upstream = await fetch(target);
+      res.status(upstream.status);
+  
+      upstream.headers.forEach((v,k) => {
+        if (k.toLowerCase() !== 'content-type') {
+          res.setHeader(k, v);
+        }
+      });
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+
+      const body = await upstream.text();
+      res.send(body);
+    } catch (err) {
+      res.status(502).send(`Proxy error: ${err.message}`);
+    }
+  });
+  
+  
 module.exports = router;

--- a/src/terminal_setup_core_and_commands.js
+++ b/src/terminal_setup_core_and_commands.js
@@ -302,12 +302,51 @@ document.addEventListener('DOMContentLoaded', () => {
         description: 'Ping a domain or IP address.\nUsage: ping [hostname]'
     };
 
-    terminalCore.getSupportedCommands()['ADDITIONAL COMMAND TWO'] = {
-        executable: (parameters) => {
-            //
-        },
-        description: ''
-    };
+terminalCore.getSupportedCommands()['curl'] = {
+  executable: (params) => {
+    // Validate
+    if (params.length !== 1) {
+      terminalCore.printToWindow("Usage: curl <url>\n", false, true);
+      return;
+    }
+    // Pull the URL from params
+    const url = params[0];
+
+    // Print a fetch banner
+    terminalCore.printToWindow(`Fetching ${url} …\n`, false, true);
+
+    fetch(`http://localhost:3000/api/proxy?url=${encodeURIComponent(url)}`)
+      .then(res => {
+        // 5) Print status + headers
+        terminalCore.printToWindow(
+          `$ HTTP ${res.status} ${res.statusText}` +
+          [...res.headers.entries()]
+            .map(([k, v]) => `\n${k}: ${v}`)
+            .join('') +
+          `\n\n`,
+          false,
+          true
+        );
+        // Return the body text
+        return res.text();
+      })
+      .then(body => {
+        // Print the HTML snippet
+        const snippet = body.slice(0, 1000);
+        terminalCore.printToWindow(
+          snippet + (body.length > 1000 ? "\n...[truncated]\n" : "\n"),
+          false,
+          true
+        );
+      })
+      .catch(err => {
+        terminalCore.printToWindow(`curl failed: ${err.message}\n`, false, true);
+      });
+  },
+  description: "Fetch a URL via your server proxy and show status, headers & a 1 000-char body snippet"
+};
+
+  
 
     terminalCore.getSupportedCommands()['ADDITIONAL COMMAND THREE'] = {
         executable: (parameters) => {


### PR DESCRIPTION
Validates that exactly one URL argument was provided.
Prints a “Fetching <url> …” banner.
Fetches http://localhost:3000/api/proxy?url=<encoded-url>.
Prints an HTTP <status> <statusText> line followed by each response header.
Displays the first 1000 characters of the response body (with ...[truncated] if longer).
Catches and reports any network or proxy errors.