### PR TITLE
Replace in-memory storage with SQLite via Sequelize

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,12 @@
             Open New Terminal Window
         </button>
         <button
+            type="button"
+            onclick="button_to_save_terminal_fs()">
+            Save Terminal File System
+        </button>
+
+        <button
                 type="button"
                 onclick="button_to_download_terminal_log()">
             Download Terminal Log

--- a/package.json
+++ b/package.json
@@ -1,13 +1,24 @@
 {
   "name": "terminal_demo",
   "version": "1.0.0",
-  "description": "",
+  "description": "**Project Team 1 (Online)**",
   "main": "terminal_setup_window.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "private": true,
   "dependencies": {
-    "@xterm/xterm": "^5.5.0"
-  }
+    "@xterm/xterm": "^5.5.0",
+    "cors": "^2.8.5",
+    "express": "^5.1.0",
+    "sequelize": "^6.37.7",
+    "sqlite3": "^5.1.7"
+  },
+  "directories": {
+    "lib": "lib"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
 }

--- a/routes/terminal.js
+++ b/routes/terminal.js
@@ -1,4 +1,4 @@
-const fetch = require("node-fetch");
+// const fetch = require("node-fetch");
 const express = require('express');
 const router = express.Router();
 const { exec } = require('child_process');

--- a/server.js
+++ b/server.js
@@ -1,13 +1,68 @@
+// server.js
 const express = require('express');
-const cors = require('cors'); 
-const app = express();
-const terminalRoutes = require('./routes/terminal');
+const cors    = require('cors');
+const { Sequelize, DataTypes } = require('sequelize');
+const path    = require('path');
+const terminalRoutes = require('./routes/terminal'); // adjust the path if needed
 
-app.use(cors()); 
+const app = express();
+
+// — Middlewares —
+app.use(cors());
 app.use(express.json());
 app.use('/api', terminalRoutes);
 
-const PORT = 3000;
-app.listen(PORT, () => {
-  console.log(`🚀 Server running at http://localhost:${PORT}`);
+// — Sequelize & SQLite setup —
+const sequelize = new Sequelize({
+  dialect: 'sqlite',
+  storage: path.join(__dirname, 'fs.sqlite'),
+  logging: false,     // turn off SQL logging
 });
+
+// Define FSStates model
+const FSState = sequelize.define('FSState', {
+  id:   { type: DataTypes.STRING, primaryKey: true },
+  data: { type: DataTypes.TEXT,   allowNull: false },
+}, {
+  tableName: 'FSStates',
+  timestamps: false,
+});
+
+// — Persistence Endpoints —
+// Save the full FS JSON under a fixed key
+app.post('/api/fs/save', async (req, res) => {
+  try {
+    await FSState.upsert({
+      id:   'terminal_file_system',
+      data: JSON.stringify(req.body),
+    });
+    res.sendStatus(204);
+  } catch (err) {
+    console.error('Save error:', err);
+    res.status(500).send({ error: err.message });
+  }
+});
+
+// Load it back
+app.get('/api/fs/load', async (req, res) => {
+  try {
+    const row = await FSState.findByPk('terminal_file_system');
+    res.json(row ? JSON.parse(row.data) : {});
+  } catch (err) {
+    console.error('Load error:', err);
+    res.status(500).send({ error: err.message });
+  }
+});
+
+// — Start Server after syncing DB —
+const PORT = process.env.PORT || 3000;
+(async () => {
+  try {
+    await sequelize.sync(); // create table if not exist
+    app.listen(PORT, () => {
+      console.log(`🚀 Server running at http://localhost:${PORT}`);
+    });
+  } catch (err) {
+    console.error('Failed to sync database:', err);
+  }
+})();

--- a/server.js
+++ b/server.js
@@ -54,6 +54,31 @@ app.get('/api/fs/load', async (req, res) => {
   }
 });
 
+// server.js (near the top, right after you instantiate `sequelize`)
+(async () => {
+  try {
+    // 1) Check the connection
+    await sequelize.authenticate();
+    console.log('Sequelize connection OK');
+
+    // 2) Sync & inspect the tables
+    await sequelize.sync();  
+    console.log('Models synced to the DB');
+
+    // 3) List all tables in the SQLite file
+    const tables = await sequelize.getQueryInterface().showAllTables();
+    console.log('Tables in SQLite:', tables);
+
+    // 4) (Optional) Run a quick find to prove the FSState model exists
+    const rows = await FSState.findAll();
+    console.log(`🗄️  FSStates table has ${rows.length} rows`);
+  } catch (err) {
+    console.error('Sequelize setup error:', err);
+    process.exit(1);
+  }
+})();
+
+
 // — Start Server after syncing DB —
 const PORT = process.env.PORT || 3000;
 (async () => {

--- a/src/terminal_core_generator.js
+++ b/src/terminal_core_generator.js
@@ -459,6 +459,29 @@ function generateTerminalCore(xtermObj, htmlElem_terminalContainer, fsRoot, supp
     xtermObj.write(` $ `);
     terminalLog.push(` $ `);
 
+    // ── Load persisted FS on startup ──
+(async () => {
+    try {
+      const resp  = await fetch('http://localhost:3000/api/fs/load');
+      const state = await resp.json();
+      if (state && state.fs) {
+        // clear out the root in place
+        fsRoot.subfolders = {};
+        fsRoot.files      = {};
+        // rebuild the FolderObject tree
+        importFS(fsRoot, state);
+        // reset pointer and cwd
+        currentTerminalFolderPointer.gotoRoot();
+        const cwd = state.cwd.startsWith('/') ? state.cwd.slice(1) : state.cwd;
+        if (cwd) currentTerminalFolderPointer.gotoPathFromRoot(cwd);
+        console.log('✅ Terminal FS loaded from server');
+      }
+    } catch (e) {
+      console.warn('Could not load FS from server', e);
+    }
+  })();
+  
+
     // Securely Release the Terminal APIs
     return {
         /*

--- a/src/terminal_setup_core_and_commands.js
+++ b/src/terminal_setup_core_and_commands.js
@@ -6,6 +6,45 @@ let
 // Set Up System Time Object
 const date = new Date();
 
+// --- paste this at the very top of terminal_setup_core_and_commands.js ---
+
+// serialize a FolderObject tree into plain JS objects
+function serializeFolder(folder) {
+  return {
+    files: { ...folder.files },
+    subfolders: Object.fromEntries(
+      Object.entries(folder.subfolders)
+        .map(([name, sub]) => [name, serializeFolder(sub)])
+    )
+  };
+}
+
+// export the full FS tree plus cwd
+function exportFS(root, cwd) {
+  return {
+    fs: serializeFolder(root),
+    cwd
+  };
+}
+
+// recursively rebuild a FolderObject tree from plain data
+function buildFolder(folder, data) {
+  folder.files = { ...data.files };
+  folder.subfolders = {};
+  for (const [name, subData] of Object.entries(data.subfolders)) {
+    folder.subfolders[name] = { parentFolder: folder, subfolders: {}, files: {} };
+    buildFolder(folder.subfolders[name], subData);
+  }
+}
+
+// import the saved state back into your in‑memory root
+function importFS(root, state) {
+  buildFolder(root, state.fs);
+}
+
+// --- end of paste ---
+
+
 document.addEventListener('DOMContentLoaded', () => {
 
     const
@@ -595,6 +634,45 @@ document.addEventListener('DOMContentLoaded', () => {
             '  files delete <path>\n' +
             '  files rename <old> <new>'
     };
+
+    supportedCommands['save'] = {
+        description: 'Persist FS to SQLite',
+        executable: () => {
+          const cwd   = currentTerminalCore.getCurrentFolderPointer().getFullPath();
+          const state = exportFS(fsRoot, cwd);
+      
+          fetch('http://localhost:3000/api/fs/save', {
+            method: 'POST',                            // ← must be POST
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(state),               // ← your JSON payload
+          })
+          .then(res => {
+            if (!res.ok) throw new Error(res.statusText);
+            currentTerminalCore.printToWindow('✅ Saved to SQLite', false, true);
+          })
+          .catch(err => {
+            currentTerminalCore.printToWindow(`Save failed: ${err}`, false, true);
+          });
+        }
+      };
+      
+      
+      supportedCommands['load'] = {
+        description: 'Load FS from SQLite',
+        executable: () => {
+          fetch('http://localhost:3000/api/fs/load')
+            .then(res => res.json())
+            .then(state => {
+              importFS(fsRoot, state);                  // you’ll need an importFS to mirror exportFS
+              // restore working directory
+              const cwd = state.cwd.startsWith('/') ? state.cwd.slice(1) : state.cwd;
+              if (cwd) currentTerminalCore.getCurrentFolderPointer().gotoPathFromRoot(cwd);
+              currentTerminalCore.printToWindow('✅ Loaded from SQLite', false, true);
+            })
+            .catch(err => currentTerminalCore.printToWindow(`Load failed: ${err}`, false, true));
+        }
+      };
+      
 
 });
 

--- a/src/terminal_setup_core_and_commands.js
+++ b/src/terminal_setup_core_and_commands.js
@@ -1,5 +1,6 @@
 let
     button_to_open_new_terminal_window = undefined,
+    button_to_save_terminal_fs = undefined,
     button_to_download_terminal_log = undefined,
     button_to_add_local_file = undefined;
 
@@ -37,7 +38,7 @@ function buildFolder(folder, data) {
   }
 }
 
-// import the saved state back into your in‑memory root
+// import the saved state back into in‑memory root
 function importFS(root, state) {
   buildFolder(root, state.fs);
 }
@@ -139,6 +140,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Automatically open one terminal window
     button_to_open_new_terminal_window();
+
+    // Save FS button handler
+    button_to_save_terminal_fs = () => {
+        const cmd = supportedCommands['save'];
+        if (cmd && typeof cmd.executable === 'function') {
+            cmd.executable();
+        } else {
+            console.error('Save command not found');
+        }
+    };
+
 
     button_to_download_terminal_log = () => {
         const


### PR DESCRIPTION
## Persistent Terminal File System with SQLite/Sequelize

This PR adds real persistence to the in‑browser terminal by saving the entire file system to a SQLite database on the server. 

- **Server side**  
  - I added **Sequelize** (an ORM) and `sqlite3` to manage a simple `FSStates` table in `fs.sqlite`.  
  - That table holds a single record (`id = 'terminal_file_system'`) containing the user's entire file system as JSON.  
  - Two new endpoints under `/api/fs`:  
    - **POST /save** → Overwrites that record with whatever JSON the frontend sends (responds 204 on success).  
    - **GET /load** → Returns the last‑saved JSON (or an empty object if nothing’s been saved yet).

- **Client side**  
  - I wrote two helper functions:  
    - `exportFS(root, cwd)` turns the live folder–and–file tree plus current directory into plain JSON.  
    - `importFS(root, state)` rebuilds that tree back into the in‑memory objects.  
  - The `save` and `load` CLI commands call the new endpoints
  - On page load, an automatic fetch of `/api/fs/load` rehydrates the files and working directory so the files survive a refresh.  
  - I also added a **Save Terminal File System** button next to the other UI buttons for one‑click saving with mouse.


